### PR TITLE
Support for multiple input files in libgen

### DIFF
--- a/libgen/libgen.py
+++ b/libgen/libgen.py
@@ -39,6 +39,7 @@
 #IMPORTS>
 import xml.dom.minidom,sys,os,re
 from datetime import datetime
+import argparse
 ############################################################################
 #EXPORT>
 __all__=['Help_xml2lib','xml2lib']
@@ -377,9 +378,7 @@ def GetDcmDict(d):
   return d
 ############################################################################
 #OTHER FUNCTIONS>
-def Help_xml2lib():
-  print("""Usage: %s <spec file> [<lib file>]
-  
+help_text="""
 Where <spec file> is a file containing the PIN descriptions
 and <lib file> is the name of the generated component description.
 The <lib file> is optional and can be generated automatically from the
@@ -486,8 +485,8 @@ QUAD -
             |   |   ..   |   |
             |   |   ..   |   |
         
-"""%os.path.split(sys.argv[0])[1])
-  sys.exit(-1)
+"""
+
 ############################################################################
 #Processing FUNCTION>
 def xml2lib(srcxmlfile,destlibfile):
@@ -542,16 +541,18 @@ def xml2lib(srcxmlfile,destlibfile):
 ############################################################################
 #MAIN FUNCTION>
 if __name__ == "__main__" :
-  if not sys.argv[1:] :#Atleast one Argument Supplied
-    Help_xml2lib()
-  if not os.path.isfile(sys.argv[1]) :#Check if the Source exists
-    Help_xml2lib()
+  parser = argparse.ArgumentParser(description=help_text,formatter_class=argparse.RawTextHelpFormatter)
+  parser.add_argument('specfile', metavar='<spec file>', help='PIN descriptions in XML')
+  parser.add_argument('-l', dest='library', metavar='<lib file>', help='output library name')
+
+  args = parser.parse_args()
+
   #File Names
-  srcfl = sys.argv[1]
+  srcfl = args.specfile
   destfl = ""
-  if sys.argv[2:] :#if Two Arguments were provided
-    destfl = sys.argv[2]
-  else:#if only One Argument
+  if args.library!=None:
+    destfl = args.library
+  else:
     fl = re.match("(.*)\..*",srcfl)
     if fl:#Create the Name of the Lib
       destfl = str(fl.group(1))+".lib"

--- a/libgen/readme.md
+++ b/libgen/readme.md
@@ -15,12 +15,13 @@ for this tool is also available.
 
 Usage
 -----
-`python libgen <.xml file> <.lib file>`
+`python libgen <.xml file> -l <.lib file>`
   
 Where `<.xml file>` is a file containing the *PIN descriptions*
-and `<.lib file>` is the name of the generated component description.
-The `<.lib file>` is **optional** and can be *generated automatically* from the
-`<.xml file>`.The `<.lib file>` name would be used to generate the `.DCM`
+and `<.lib file>` is the name of the generated component description. Multiple
+`<.xml file>`s can be specified to create a multi-component library. The `<.lib file>`
+ is **optional** and can be *generated automatically* from the first
+`<.xml file>`. The `<.lib file>` name would be used to generate the `.DCM`
 which contains the *description* and *keywords* for the component.
 
 `<.xml file>` is an XML format file, containing the *pin descriptions* and


### PR DESCRIPTION
The following patch adds support for specifying multiple input XML files. The output is a library with multiple components.

There are two changes to the interface:
* The library name is now an optional argument, since the second positional argument can be an XML file.
* The DCM file is always created, even if description is not available.